### PR TITLE
New command line parameter and trailing whitespace fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ options:
 - `--py36`
 - `-S` / `--skip-string-normalization`
 
+Following additional parameters can be used:
+
+- `-E` / `--skip-errors`
+
 `blacken-docs` will format code in the following block types:
 
 (markdown)

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -14,7 +14,7 @@ import black
 MD_RE = re.compile(
     r'(?P<before>^(?P<indent> *)```python\n)'
     r'(?P<code>.*?)'
-    r'(?P<after>^(?P=indent)```$)',
+    r'(?P<after>^(?P=indent)```\s*$)',
     re.DOTALL | re.MULTILINE,
 )
 RST_RE = re.compile(

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -2,11 +2,15 @@ import argparse
 import contextlib
 import re
 import textwrap
+from types import SimpleNamespace
 from typing import Any
+from typing import Dict
 from typing import Generator
+from typing import List
 from typing import Match
 from typing import Optional
 from typing import Sequence
+from typing import Tuple
 
 import black
 
@@ -34,13 +38,17 @@ class CodeBlockError(ValueError):
     pass
 
 
-def format_str(src: str, **black_opts: Any) -> str:
+def format_str(
+    src: str, **black_opts: Any,
+) -> Tuple[str, Sequence[CodeBlockError]]:
+    errors: List[CodeBlockError] = []
+
     @contextlib.contextmanager
     def _reraise(match: Match[str]) -> Generator[None, None, None]:
         try:
             yield
         except Exception as e:
-            raise CodeBlockError(match.start(), e)
+            errors.append(CodeBlockError(match.start(), e))
 
     def _md_match(match: Match[str]) -> str:
         code = textwrap.dedent(match['code'])
@@ -62,18 +70,20 @@ def format_str(src: str, **black_opts: Any) -> str:
 
     src = MD_RE.sub(_md_match, src)
     src = RST_RE.sub(_rst_match, src)
-    return src
+    return src, errors
 
 
-def format_file(filename: str, **black_opts: Any) -> int:
+def format_file(
+    filename: str, extra_opts: Any, black_opts: Dict[str, Any],
+) -> int:
     with open(filename, encoding='UTF-8') as f:
         contents = f.read()
-    try:
-        new_contents = format_str(contents, **black_opts)
-    except CodeBlockError as exc:
-        offset, orig_exc = exc.args
+    new_contents, errors = format_str(contents, **black_opts)
+    for error in errors:
+        offset, orig_exc = error.args
         lineno = contents[:offset].count('\n') + 1
         print(f'{filename}:{lineno}: code block parse error {orig_exc}')
+    if len(errors) > 0 and not extra_opts.skip_errors:
         return 1
     if contents != new_contents:
         print(f'{filename}: Rewriting...')
@@ -93,6 +103,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         '-S', '--skip-string-normalization', action='store_true',
     )
+    parser.add_argument("-E", "--skip-errors", action="store_true")
     parser.add_argument('filenames', nargs='*')
     args = parser.parse_args(argv)
 
@@ -100,6 +111,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         'line_length': args.line_length,
         'mode': black.FileMode.AUTO_DETECT,
     }
+    extra_opts = SimpleNamespace(**{
+        'skip_errors': args.skip_errors,
+    })
     if args.py36_plus:
         black_opts['mode'] |= black.FileMode.PYTHON36
     if args.skip_string_normalization:
@@ -107,7 +121,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     retv = 0
     for filename in args.filenames:
-        retv |= format_file(filename, **black_opts)
+        retv |= format_file(filename, extra_opts, black_opts)
     return retv
 
 

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -10,7 +10,7 @@ OPTS = {
 
 
 def test_format_src_trivial():
-    assert blacken_docs.format_str('', **OPTS) == ''
+    assert blacken_docs.format_str('', **OPTS)[0] == ''
 
 
 def test_format_src_markdown_simple():
@@ -19,7 +19,7 @@ def test_format_src_markdown_simple():
         'f(1,2,3)\n'
         '```\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after = blacken_docs.format_str(before, **OPTS)[0]
     assert after == (
         '```python\n'
         'f(1, 2, 3)\n'
@@ -35,7 +35,7 @@ def test_format_src_indented_markdown():
         '  ```\n'
         '- also this\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after = blacken_docs.format_str(before, **OPTS)[0]
     assert after == (
         '- do this pls:\n'
         '  ```python\n'
@@ -55,7 +55,7 @@ def test_format_src_rst():
         '\n'
         'world\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after = blacken_docs.format_str(before, **OPTS)[0]
     assert after == (
         'hello\n'
         '\n'
@@ -80,7 +80,7 @@ def test_format_src_rst_indented():
         '\n'
         '    world\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after = blacken_docs.format_str(before, **OPTS)[0]
     assert after == (
         '.. versionadded:: 3.1\n'
         '\n'
@@ -104,7 +104,7 @@ def test_format_src_rst_with_highlight_directives():
         '    def foo():\n'
         '        bar(1,2,3)\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after = blacken_docs.format_str(before, **OPTS)[0]
     assert after == (
         '.. code-block:: python\n'
         '    :lineno-start: 10\n'
@@ -219,6 +219,30 @@ def test_integration_syntax_error(tmpdir, capsys):
     out, _ = capsys.readouterr()
     assert out.startswith(f'{f}:1: code block parse error')
     assert f.read() == (
+        '```python\n'
+        'f(\n'
+        '```\n'
+    )
+
+
+def test_integration_ignored_syntax_error(tmpdir, capsys):
+    f = tmpdir.join('f.md')
+    f.write(
+        '```python\n'
+        'f( )\n'
+        '```\n'
+        '\n'
+        '```python\n'
+        'f(\n'
+        '```\n',
+    )
+    assert blacken_docs.main((str(f), '--skip-errors'))
+    out, _ = capsys.readouterr()
+    assert f.read() == (
+        '```python\n'
+        'f()\n'
+        '```\n'
+        '\n'
         '```python\n'
         'f(\n'
         '```\n'


### PR DESCRIPTION
This PR adds the `--skip-errors` command line parameter. If set, files will be rewritten, even if one or more code blocks can not be formatted by `black`. This is useful for syntax additions to Python that aren't yet supported by `black`.
Additionally, the markdown code block regex is made less strict in regards to end marker trailing whitespaces.

With kind regards,
Philip Trauner