### PR TITLE
Allow trailing whitespaces for markdown code block end markers

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -14,7 +14,7 @@ import black
 MD_RE = re.compile(
     r'(?P<before>^(?P<indent> *)```python\n)'
     r'(?P<code>.*?)'
-    r'(?P<after>^(?P=indent)```$)',
+    r'(?P<after>^(?P=indent)```\s*$)',
     re.DOTALL | re.MULTILINE,
 )
 RST_RE = re.compile(

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -27,6 +27,20 @@ def test_format_src_markdown_simple():
     )
 
 
+def test_format_src_markdown_trailing_whitespace():
+    before = (
+        '```python\n'
+        'f(1,2,3)\n'
+        '```    \n'
+    )
+    after = blacken_docs.format_str(before, **OPTS)
+    assert after == (
+        '```python\n'
+        'f(1, 2, 3)\n'
+        '```    \n'
+    )
+
+
 def test_format_src_indented_markdown():
     before = (
         '- do this pls:\n'


### PR DESCRIPTION
First out of two PRs as requested in #9.  
[Automatically stripping trailing whitespaces as a pre-processing step](https://github.com/asottile/blacken-docs/pull/9#discussion_r217930041) also works in theory, but I think a more lenient approach is beneficial, because many WYSIWYG Markdown editors produce horribly formatted markup.

With kind regards,
Philip Trauner