### PR TITLE
New command line parameter `--skip-errors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ options:
 - `--py36`
 - `-S` / `--skip-string-normalization`
 
+Following additional parameters can be used:
+
+ - `-E` / `--skip-errors`
+
 `blacken-docs` will format code in the following block types:
 
 (markdown)

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -10,7 +10,8 @@ OPTS = {
 
 
 def test_format_src_trivial():
-    assert blacken_docs.format_str('', **OPTS) == ''
+    after, _ = blacken_docs.format_str('', **OPTS)
+    assert after == ''
 
 
 def test_format_src_markdown_simple():
@@ -19,7 +20,7 @@ def test_format_src_markdown_simple():
         'f(1,2,3)\n'
         '```\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after, _ = blacken_docs.format_str(before, **OPTS)
     assert after == (
         '```python\n'
         'f(1, 2, 3)\n'
@@ -35,7 +36,7 @@ def test_format_src_indented_markdown():
         '  ```\n'
         '- also this\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after, _ = blacken_docs.format_str(before, **OPTS)
     assert after == (
         '- do this pls:\n'
         '  ```python\n'
@@ -55,7 +56,7 @@ def test_format_src_rst():
         '\n'
         'world\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after, _ = blacken_docs.format_str(before, **OPTS)
     assert after == (
         'hello\n'
         '\n'
@@ -80,7 +81,7 @@ def test_format_src_rst_indented():
         '\n'
         '    world\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after, _ = blacken_docs.format_str(before, **OPTS)
     assert after == (
         '.. versionadded:: 3.1\n'
         '\n'
@@ -104,7 +105,7 @@ def test_format_src_rst_with_highlight_directives():
         '    def foo():\n'
         '        bar(1,2,3)\n'
     )
-    after = blacken_docs.format_str(before, **OPTS)
+    after, _ = blacken_docs.format_str(before, **OPTS)
     assert after == (
         '.. code-block:: python\n'
         '    :lineno-start: 10\n'
@@ -219,6 +220,30 @@ def test_integration_syntax_error(tmpdir, capsys):
     out, _ = capsys.readouterr()
     assert out.startswith(f'{f}:1: code block parse error')
     assert f.read() == (
+        '```python\n'
+        'f(\n'
+        '```\n'
+    )
+
+
+def test_integration_ignored_syntax_error(tmpdir, capsys):
+    f = tmpdir.join('f.md')
+    f.write(
+        '```python\n'
+        'f( )\n'
+        '```\n'
+        '\n'
+        '```python\n'
+        'f(\n'
+        '```\n',
+    )
+    assert blacken_docs.main((str(f), '--skip-errors'))
+    out, _ = capsys.readouterr()
+    assert f.read() == (
+        '```python\n'
+        'f()\n'
+        '```\n'
+        '\n'
         '```python\n'
         'f(\n'
         '```\n'


### PR DESCRIPTION
Second PRs as requested in #9.

This PR adds the `--skip-errors` command line parameter. If set, files will be rewritten, even if one or more code blocks can not be formatted by `black`. This is useful for syntax additions to Python that aren't yet supported by `black`.

With kind regards,
Philip Trauner