### PR TITLE
Remove universal wheel from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,6 @@ python_requires = >=3.6
 console_scripts =
     blacken-docs=blacken_docs:main
 
-[bdist_wheel]
-universal = True
-
 [mypy]
 check_untyped_defs = true
 disallow_any_generics = true


### PR DESCRIPTION
The project is Python 3 only, therefore the wheel is not universal.

From https://wheel.readthedocs.io/en/stable/user_guide.html. Emphasis
mine.

> If your project contains no C extensions and **is expected to work on
> both Python 2 and 3**, you will want to tell wheel to produce
> universal wheels by adding this to your setup.cfg file: