### PR TITLE
Correct --target-version argument definition

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -100,9 +100,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument(
         '-t',
         '--target-version',
+        action='append',
         type=lambda v: black.TargetVersion[v.upper()],
-        nargs='+',
-        default=set(),
+        default=[],
         help=f'choices: {[v.name.lower() for v in black.TargetVersion]}',
         dest='target_versions',
     )

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -205,6 +205,50 @@ def test_integration_py36(tmpdir):
     )
 
 
+def test_integration_filename_last(tmpdir):
+    f = tmpdir.join('f.md')
+    f.write(
+        '```python\n'
+        'def very_very_long_function_name(\n'
+        '    very_very_very_very_very_very,\n'
+        '    very_very_very_very_very_very,\n'
+        '    *long_long_long_long_long_long\n'
+        '):\n'
+        '    pass\n'
+        '```\n',
+    )
+    assert not blacken_docs.main((str(f),))
+    assert blacken_docs.main(('--target-version', 'py36', str(f)))
+    assert f.read() == (
+        '```python\n'
+        'def very_very_long_function_name(\n'
+        '    very_very_very_very_very_very,\n'
+        '    very_very_very_very_very_very,\n'
+        '    *long_long_long_long_long_long,\n'
+        '):\n'
+        '    pass\n'
+        '```\n'
+    )
+
+
+def test_integration_multiple_target_version(tmpdir):
+    f = tmpdir.join('f.md')
+    f.write(
+        '```python\n'
+        'def very_very_long_function_name(\n'
+        '    very_very_very_very_very_very,\n'
+        '    very_very_very_very_very_very,\n'
+        '    *long_long_long_long_long_long\n'
+        '):\n'
+        '    pass\n'
+        '```\n',
+    )
+    assert not blacken_docs.main((str(f),))
+    assert not blacken_docs.main(
+        ('--target-version', 'py27', '--target-version', 'py36', str(f)),
+    )
+
+
 def test_integration_skip_string_normalization(tmpdir):
     f = tmpdir.join('f.md')
     f.write(


### PR DESCRIPTION
Black defines --target-version using Click's multiple=True. This is
defined as:

https://click.palletsprojects.com/en/7.x/options/

> Multiple Options
>
> Similarly to nargs, there is also the case of wanting to support a
> parameter being provided multiple times to and have all values
> recorded – not just the last one. For instance, git commit -m foo -m
> bar would record two lines for the commit message: foo and bar.

In the argparse world, this is the 'append' action.

Fixes: #23