### PR TITLE
support Sphinx `.. ipython:: python` blocks

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -21,7 +21,7 @@ MD_RE = re.compile(
 )
 RST_RE = re.compile(
     r'(?P<before>'
-    r'^(?P<indent> *)\.\. (code-block|sourcecode):: python\n'
+    r'^(?P<indent> *)\.\. (code-block|sourcecode|ipython):: python\n'
     r'((?P=indent) +:.*\n)*'
     r'\n*'
     r')'


### PR DESCRIPTION
See: https://ipython.readthedocs.io/en/stable/sphinxext.html#writing-pure-python-code

The code syntax is equivalent to `.. code-block:: python`, so the change is trivial.
