### PR TITLE
Support LaTeX minted python blocks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     entry: blacken-docs
     language: python
     language_version: python3
-    files: '\.(rst|md|markdown)$'
+    files: '\.(rst|md|markdown|tex)$'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run `black` on python code blocks in documentation files.
 ## usage
 
 `blacken-docs` provides a single executable (`blacken-docs`) which will modify
-`.rst` / `.md` files in place.
+`.rst` / `.md` / `.tex` files in place.
 
 It currently supports the following [`black`](https://github.com/psf/black)
 options:
@@ -42,6 +42,14 @@ Following additional parameters can be used:
 
         def hello():
             print("hello world")
+```
+
+(latex)
+```latex
+\begin{minted}{python}
+def hello():
+    print("hello world")
+\end{minted}
 ```
 
 ## usage with pre-commit

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -57,6 +57,48 @@ def test_format_src_indented_markdown():
     )
 
 
+def test_format_src_latex_minted():
+    # Nicer style to put the \begin and \end on new lines,
+    # but not actually required for the begin line
+    before = (
+        'hello\n'
+        '\\begin{minted}{python}\n'
+        'f(1,2,3)\n'
+        '\\end{minted}\n'
+        'world!'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        'hello\n'
+        '\\begin{minted}{python}\n'
+        'f(1, 2, 3)\n'
+        '\\end{minted}\n'
+        'world!'
+    )
+
+
+def test_format_src_latex_minted_indented():
+    # Personaly I would have minted python code all flush left,
+    # with only the Python code's own four space indentation:
+    before = (
+        'hello\n'
+        '  \\begin{minted}{python}\n'
+        '    if True:\n'
+        '      f(1,2,3)\n'
+        '  \\end{minted}\n'
+        'world!'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        'hello\n'
+        '  \\begin{minted}{python}\n'
+        '  if True:\n'
+        '      f(1, 2, 3)\n'
+        '  \\end{minted}\n'
+        'world!'
+    )
+
+
 def test_format_src_rst():
     before = (
         'hello\n'


### PR DESCRIPTION
Using ``\begin{minted}{python}`` environments is one of the most popular ways to write literal blocks of Python code in LaTeX with syntax colouring.

This pull request was written and tested on the Biopython Tutorial, currently written in LaTeX using minted blocks for ``python`` code (and more code using ``pycon`` but that needs #8 to work), see e.g.
https://github.com/biopython/biopython/blob/biopython-175/Doc/Tutorial.tex

We previously used ``\verbatim`` blocks in LaTeX, but these are not specific to Python code and so should not be formatted with black (same issue with RST and ``::`` blocks, #21): https://github.com/biopython/biopython/commit/98e84b75d3f33c7658705e9c33043b12102b3251

The other popular convention for syntax coloured Python code within LaTeX is ``\begin{listing}[language=Python]`` and it would be relatively straightforward to cover that as well.