### PR TITLE
Allow whitespace between MD fenced code block and language

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -14,7 +14,7 @@ import black
 
 
 MD_RE = re.compile(
-    r'(?P<before>^(?P<indent> *)```python\n)'
+    r'(?P<before>^(?P<indent> *)```\s*python\n)'
     r'(?P<code>.*?)'
     r'(?P<after>^(?P=indent)```\s*$)',
     re.DOTALL | re.MULTILINE,

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -25,6 +25,20 @@ def test_format_src_markdown_simple():
     )
 
 
+def test_format_src_markdown_leading_whitespace():
+    before = (
+        '```   python\n'
+        'f(1,2,3)\n'
+        '```\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        '```   python\n'
+        'f(1, 2, 3)\n'
+        '```\n'
+    )
+
+
 def test_format_src_markdown_trailing_whitespace():
     before = (
         '```python\n'


### PR DESCRIPTION
See e.g. https://spec.commonmark.org/0.29/#fenced-code-blocks