### PR TITLE
Add the ability to handle Jupyter magics in code blocks

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -45,9 +45,9 @@ PYTHONTEX_RE = re.compile(
 )
 INDENT_RE = re.compile('^ +(?=[^ ])', re.MULTILINE)
 TRAILING_NL_RE = re.compile(r'\n+\Z', re.MULTILINE)
-JUPYTER_MAGICS_RE = re.compile(r"(^\s*)(%)", re.M)
-_PLACEHOLDER = r"# JUPYTER_MAGICS_PLACEHOLDER"
-UNDO_JUPYTER_MAGICS_RE = re.compile(rf"(^\s*)({_PLACEHOLDER})", re.M)
+JUPYTER_MAGICS_RE = re.compile(r'(^\s*)(%)', re.M)
+_PLACEHOLDER = r'# JUPYTER_MAGICS_PLACEHOLDER'
+UNDO_JUPYTER_MAGICS_RE = re.compile(rf'(^\s*)({_PLACEHOLDER})', re.M)
 
 
 class CodeBlockError(NamedTuple):
@@ -92,12 +92,12 @@ def format_str(
         code = textwrap.indent(code, match['indent'])
         return f'{match["before"]}{code}{match["after"]}'
 
-    src = JUPYTER_MAGICS_RE.sub(f"\g<1>{_PLACEHOLDER}%", src)
+    src = JUPYTER_MAGICS_RE.sub(fr'\g<1>{_PLACEHOLDER}%', src)
     src = MD_RE.sub(_md_match, src)
     src = RST_RE.sub(_rst_match, src)
     src = LATEX_RE.sub(_latex_match, src)
     src = PYTHONTEX_RE.sub(_latex_match, src)
-    src = UNDO_JUPYTER_MAGICS_RE.sub(r"\g<1>", src)
+    src = UNDO_JUPYTER_MAGICS_RE.sub(r'\g<1>', src)
     return src, errors
 
 

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -45,6 +45,9 @@ PYTHONTEX_RE = re.compile(
 )
 INDENT_RE = re.compile('^ +(?=[^ ])', re.MULTILINE)
 TRAILING_NL_RE = re.compile(r'\n+\Z', re.MULTILINE)
+JUPYTER_MAGICS_RE = re.compile(r"(^\s*)(%)", re.M)
+_PLACEHOLDER = r"# JUPYTER_MAGICS_PLACEHOLDER"
+UNDO_JUPYTER_MAGICS_RE = re.compile(rf"(^\s*)({_PLACEHOLDER})", re.M)
 
 
 class CodeBlockError(NamedTuple):
@@ -89,10 +92,12 @@ def format_str(
         code = textwrap.indent(code, match['indent'])
         return f'{match["before"]}{code}{match["after"]}'
 
+    src = JUPYTER_MAGICS_RE.sub(f"\g<1>{_PLACEHOLDER}%", src)
     src = MD_RE.sub(_md_match, src)
     src = RST_RE.sub(_rst_match, src)
     src = LATEX_RE.sub(_latex_match, src)
     src = PYTHONTEX_RE.sub(_latex_match, src)
+    src = UNDO_JUPYTER_MAGICS_RE.sub(r"\g<1>", src)
     return src, errors
 
 

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -53,23 +53,41 @@ def test_format_src_markdown_trailing_whitespace():
     )
 
 
-def test_format_src_indented_markdown_with_jupyter_magic():
+def test_format_src_indented_markdown():
     before = (
-        "- do this pls:\n"
-        "  ```python\n"
-        "  %%opts\n"
-        "  f(1,2,3)\n"
-        "  ```\n"
-        "- also this\n"
+        '- do this pls:\n'
+        '  ```python\n'
+        '  f(1,2,3)\n'
+        '  ```\n'
+        '- also this\n'
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
-        "- do this pls:\n"
-        "  ```python\n"
-        "  %%opts\n"
-        "  f(1, 2, 3)\n"
-        "  ```\n"
-        "- also this\n"
+        '- do this pls:\n'
+        '  ```python\n'
+        '  f(1, 2, 3)\n'
+        '  ```\n'
+        '- also this\n'
+    )
+
+
+def test_format_src_indented_markdown_with_jupyter_magic():
+    before = (
+        '- do this pls:\n'
+        '  ```python\n'
+        '  %%opts\n'
+        '  f(1,2,3)\n'
+        '  ```\n'
+        '- also this\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        '- do this pls:\n'
+        '  ```python\n'
+        '  %%opts\n'
+        '  f(1, 2, 3)\n'
+        '  ```\n'
+        '- also this\n'
     )
 
 

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -53,21 +53,23 @@ def test_format_src_markdown_trailing_whitespace():
     )
 
 
-def test_format_src_indented_markdown():
+def test_format_src_indented_markdown_with_jupyter_magic():
     before = (
-        '- do this pls:\n'
-        '  ```python\n'
-        '  f(1,2,3)\n'
-        '  ```\n'
-        '- also this\n'
+        "- do this pls:\n"
+        "  ```python\n"
+        "  %%opts\n"
+        "  f(1,2,3)\n"
+        "  ```\n"
+        "- also this\n"
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
-        '- do this pls:\n'
-        '  ```python\n'
-        '  f(1, 2, 3)\n'
-        '  ```\n'
-        '- also this\n'
+        "- do this pls:\n"
+        "  ```python\n"
+        "  %%opts\n"
+        "  f(1, 2, 3)\n"
+        "  ```\n"
+        "- also this\n"
     )
 
 


### PR DESCRIPTION
Several popular packages use Jupyter magics (`%`) in code cells to set some options.

For example, just to name a few IPython, ipyparallel, and HoloViews do this.

With this PR, blacken-docs is able to format cells that contain `%%someoption`.