### PR TITLE
Preserve indented output in pycon blocks

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -125,7 +125,7 @@ def format_str(
                 fragment = None
 
         for line in match['code'].splitlines():
-            line = line.lstrip()
+            orig_line, line = line, line.lstrip()
             continuation_match = PYCON_CONTINUATION_RE.match(line)
             if continuation_match:
                 assert fragment is not None
@@ -133,9 +133,10 @@ def format_str(
             else:
                 finish_fragment()
                 if line.startswith(PYCON_PREFIX):
+                    indentation = len(orig_line) - len(line)
                     fragment = line[len(PYCON_PREFIX):] + '\n'
                 else:
-                    code += line + '\n'
+                    code += orig_line[indentation:] + '\n'
         finish_fragment()
 
         min_indent = min(INDENT_RE.findall(match['code']))

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -659,3 +659,16 @@ def test_format_src_rst_pycon_empty_line():
         '    ...     1,\n'
         '    ... ]\n'
     )
+
+
+def test_format_src_rst_pycon_preserves_output_indentation():
+    before = (
+        '.. code-block:: pycon\n'
+        '\n'
+        '    >>> 1 / 0\n'
+        '    Traceback (most recent call last):\n'
+        '      File "<stdin>", line 1, in <module>\n'
+        '    ZeroDivisionError: division by zero\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == before


### PR DESCRIPTION
Bug introduce in commit 32d9c0781c994e0fa7c769bc3e8ba0d7bb413100 that
erroneously stripped all leading white space.