### PR TITLE
add sphinx doctest support

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -27,9 +27,14 @@ MD_PYCON_RE = re.compile(
 )
 PY_LANGS = '(python|py|sage|python3|py3|numpy)'
 BLOCK_TYPES = '(code|code-block|sourcecode|ipython)'
+DOCTEST_TYPES = '(testsetup|testcleanup|testcode)'
 RST_RE = re.compile(
     rf'(?P<before>'
-    rf'^(?P<indent> *)\.\. (jupyter-execute::|{BLOCK_TYPES}:: {PY_LANGS})\n'
+    rf'^(?P<indent> *)\.\. ('
+    rf'jupyter-execute::|'
+    rf'{BLOCK_TYPES}:: {PY_LANGS}|'
+    rf'{DOCTEST_TYPES}::.*'
+    rf')\n'
     rf'((?P=indent) +:.*\n)*'
     rf'\n*'
     rf')'
@@ -38,7 +43,7 @@ RST_RE = re.compile(
 )
 RST_PYCON_RE = re.compile(
     r'(?P<before>'
-    r'(?P<indent> *)\.\. (code|code-block):: pycon\n'
+    r'(?P<indent> *)\.\. ((code|code-block):: pycon|doctest::.*)\n'
     r'((?P=indent) +:.*\n)*'
     r'\n*'
     r')'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -153,6 +153,51 @@ def test_format_src_rst():
     )
 
 
+def test_format_src_rst_sphinx_doctest():
+    before = (
+        '.. testsetup:: group1\n'
+        '\n'
+        '   import parrot  \n'
+        '   mock = SomeMock( )\n'
+        '\n'
+        '.. testcleanup:: group1\n'
+        '\n'
+        '   mock.stop( )\n'
+        '\n'
+        '.. doctest:: group1\n'
+        '\n'
+        '   >>> parrot.voom( 3000 )\n'
+        '   This parrot wouldn\'t voom if you put 3000 volts through it!\n'
+        '\n'
+        '.. testcode::\n'
+        '\n'
+        '   parrot.voom( 3000 )\n'
+        '\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        '.. testsetup:: group1\n'
+        '\n'
+        '   import parrot\n'
+        '\n'
+        '   mock = SomeMock()\n'
+        '\n'
+        '.. testcleanup:: group1\n'
+        '\n'
+        '   mock.stop()\n'
+        '\n'
+        '.. doctest:: group1\n'
+        '\n'
+        '   >>> parrot.voom(3000)\n'
+        '   This parrot wouldn\'t voom if you put 3000 volts through it!\n'
+        '\n'
+        '.. testcode::\n'
+        '\n'
+        '   parrot.voom(3000)\n'
+        '\n'
+    )
+
+
 def test_format_src_rst_indented():
     before = (
         '.. versionadded:: 3.1\n'


### PR DESCRIPTION
Implement #78

I added `RST_DOCTEST_RE` and `RST_DOCTEST_PYCON_RE` as two new regexes since doctest is just for python and it is instead a "group" that follows the directive, not a language specifier.

~I also added Python 3.8 to the tox test environment.~