### PR TITLE
Format invisible doctest code blocks

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -32,6 +32,7 @@ RST_RE = re.compile(
     rf'(?P<before>'
     rf'^(?P<indent> *)\.\. ('
     rf'jupyter-execute::|'
+    rf'invisible-code-block::? {PY_LANGS}|'
     rf'{BLOCK_TYPES}:: {PY_LANGS}|'
     rf'{DOCTEST_TYPES}::.*'
     rf')\n'


### PR DESCRIPTION
Sybil, a doctest library, recommends using "invisible" code blocks (really rst comments)
for setup code which should not be visible in the compiled docs.  We format it anyway.

See https://sybil.readthedocs.io/en/latest/parsers.html#codeblock

(I'm including this in `shed`, which imitates much of `blacken-docs`, and thought I should offer an upstream patch)