### PR TITLE
Fix nested code block syntax

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -25,14 +25,14 @@ MD_PYCON_RE = re.compile(
     r'(?P<after>^(?P=indent)```.*$)',
     re.DOTALL | re.MULTILINE,
 )
-PY_LANGS = '(python|py|sage|python3|py3|numpy)'
+RST_PY_LANGS = frozenset(('python', 'py', 'sage', 'python3', 'py3', 'numpy'))
 BLOCK_TYPES = '(code|code-block|sourcecode|ipython)'
 DOCTEST_TYPES = '(testsetup|testcleanup|testcode)'
 RST_RE = re.compile(
     rf'(?P<before>'
     rf'^(?P<indent> *)\.\. ('
     rf'jupyter-execute::|'
-    rf'{BLOCK_TYPES}:: {PY_LANGS}|'
+    rf'{BLOCK_TYPES}:: (?P<lang>\w+)|'
     rf'{DOCTEST_TYPES}::.*'
     rf')\n'
     rf'((?P=indent) +:.*\n)*'
@@ -103,6 +103,9 @@ def format_str(
         return f'{match["before"]}{code}{match["after"]}'
 
     def _rst_match(match: Match[str]) -> str:
+        lang = match['lang']
+        if lang is not None and lang not in RST_PY_LANGS:
+            return match[0]
         min_indent = min(INDENT_RE.findall(match['code']))
         trailing_ws_match = TRAILING_NL_RE.search(match['code'])
         assert trailing_ws_match

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -286,6 +286,21 @@ def test_format_src_rst_with_highlight_directives():
     )
 
 
+def test_format_src_rst_python_inside_non_python_code_block():
+    before = (
+        'blacken-docs does changes like:\n'
+        '\n'
+        '.. code-block:: diff\n'
+        '\n'
+        '     .. code-block:: python\n'
+        '\n'
+        "    -    'Hello World'\n"
+        '    +    "Hello World"\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == before
+
+
 def test_integration_ok(tmpdir, capsys):
     f = tmpdir.join('f.md')
     f.write(


### PR DESCRIPTION
Fixes #126.

Adjust the RST regex to match all code blocks, and then for non-Python blocks, return the source unaltered. This works since `re.sub()` only finds non-overlapping matches.