### PR TITLE
support for orgmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ def hello():
 \end{pycode}
 ```
 
+(orgmode)
+```markdown
+#+begin_src python
+def hello():
+    print("hello world")
+#+end_src
+```
+
 (markdown/rst in python docstrings)
 ```python
 def f():

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -73,6 +73,11 @@ PYTHONTEX_RE = re.compile(
     rf'(?P<after>^(?P=indent)\\end{{(?P=lang)}}\s*$)',
     re.DOTALL | re.MULTILINE,
 )
+ORGMODE_RE = re.compile(
+    rf'(?P<before>^(?P<indent> *)\#\+begin_src python[^\n]*\n
+    rf'(?P<after>^(?P=indent)\#\+end_src\s*$)',
+    re.DOTALL | re.MULTILINE,
+)
 INDENT_RE = re.compile('^ +(?=[^ ])', re.MULTILINE)
 TRAILING_NL_RE = re.compile(r'\n+\Z', re.MULTILINE)
 
@@ -190,6 +195,7 @@ def format_str(
     src = LATEX_RE.sub(_latex_match, src)
     src = LATEX_PYCON_RE.sub(_latex_pycon_match, src)
     src = PYTHONTEX_RE.sub(_latex_match, src)
+    src = ORGMODE_RE.sub(_latex_match, src)
     return src, errors
 
 

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -186,11 +186,11 @@ def format_str(
 
     def _orgmode_match(match: Match[str]) -> str:
         code = textwrap.dedent(match['code'])
-        code = re.sub(r'( *<<)', r'#\1', code)
+        code = re.sub(r'( *<<.*>>)', r'#\1', code)
         with _collect_error(match):
             code = black.format_str(code, mode=black_mode)
         code = textwrap.indent(code, match['indent'])
-        code = re.sub(r'#( *<<)', r'\1', code)
+        code = re.sub(r'#( *<<.*>>)', r'\1', code)
         return f'{match["before"]}{code}{match["after"]}'
 
     def _latex_pycon_match(match: Match[str]) -> str:

--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -186,11 +186,11 @@ def format_str(
 
     def _orgmode_match(match: Match[str]) -> str:
         code = textwrap.dedent(match['code'])
-        code = re.sub(r'( *<<.*>>)', r'#\1', code)
+        code = re.sub(r'( *<<.*>>)', r'# #\1', code)
         with _collect_error(match):
             code = black.format_str(code, mode=black_mode)
         code = textwrap.indent(code, match['indent'])
-        code = re.sub(r'#( *<<.*>>)', r'\1', code)
+        code = re.sub(r'# #( *<<.*>>)', r'\1', code)
         return f'{match["before"]}{code}{match["after"]}'
 
     def _latex_pycon_match(match: Match[str]) -> str:

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -176,18 +176,24 @@ def test_src_pythontex(tmpdir):
 def test_src_orgmode(tmpdir):
     before = (
         'hello\n'
-        '#+begin_src python :exports both :results outut\n'
+        '#+begin_src python  :tangle "hello_world.py" :exports both :results output\n'
         'f(1,2,3)\n'
         'a=42\n'
+        '\n'
+        '    <<noweb snippet>>\n'
+        '\n'
         '#+end_src\n'
         'world!'
     )
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
         'hello\n'
-        '#+begin_src python :exports both :results outut\n'
+        '#+begin_src python  :tangle "hello_world.py" :exports both :results output\n'
         'f(1, 2, 3)\n'
         'a = 42\n'
+        '\n'
+        '    <<noweb snippet>>\n'
+        '\n'
         '#+end_src\n'
         'world!'
     )

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -176,7 +176,7 @@ def test_src_pythontex(tmpdir):
 def test_src_orgmode(tmpdir):
     before = (
         'hello\n'
-        '#+begin_src python  :tangle "hello_world.py" :exports both :results output\n'
+        '#+begin_src python  :tangle "hello_world.py" :exports both\n'
         'f(1,2,3)\n'
         'a=42\n'
         '\n'
@@ -188,7 +188,7 @@ def test_src_orgmode(tmpdir):
     after, _ = blacken_docs.format_str(before, BLACK_MODE)
     assert after == (
         'hello\n'
-        '#+begin_src python  :tangle "hello_world.py" :exports both :results output\n'
+        '#+begin_src python  :tangle "hello_world.py" :exports both\n'
         'f(1, 2, 3)\n'
         'a = 42\n'
         '\n'

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -173,6 +173,26 @@ def test_src_pythontex(tmpdir):
     )
 
 
+def test_src_orgmode(tmpdir):
+    before = (
+        'hello\n'
+        '#+begin_src python :exports both :results outut\n'
+        'f(1,2,3)\n'
+        'a=42\n'
+        '#+end_src\n'
+        'world!'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        'hello\n'
+        '#+begin_src python :exports both :results outut\n'
+        'f(1, 2, 3)\n'
+        'a = 42\n'
+        '#+end_src\n'
+        'world!'
+    )
+
+
 def test_format_src_rst():
     before = (
         'hello\n'


### PR DESCRIPTION
Org mode (via org babel) allows to include python source blocks. The python code can be edited right away in org mode, but it's a bit of pain to call blacken every time on each code block. (It must be doable in elisp, but for the moment I don't know how to do that). It's much more handy to run blacken-docs on the org file itself. 