### PR TITLE
Add optional {code-cell} to python markdown code blocks

### DIFF
--- a/blacken_docs.py
+++ b/blacken_docs.py
@@ -13,7 +13,7 @@ import black
 
 
 MD_RE = re.compile(
-    r'(?P<before>^(?P<indent> *)```\s*python\n)'
+    r'(?P<before>^(?P<indent> *)```(\{code-cell\})?\s*python\n)'
     r'(?P<code>.*?)'
     r'(?P<after>^(?P=indent)```\s*$)',
     re.DOTALL | re.MULTILINE,

--- a/tests/blacken_docs_test.py
+++ b/tests/blacken_docs_test.py
@@ -27,6 +27,20 @@ def test_format_src_markdown_simple():
     )
 
 
+def test_format_src_markdown_code_cell():
+    before = (
+        '```{code-cell} python\n'
+        'f(1,2,3)\n'
+        '```\n'
+    )
+    after, _ = blacken_docs.format_str(before, BLACK_MODE)
+    assert after == (
+        '```{code-cell} python\n'
+        'f(1, 2, 3)\n'
+        '```\n'
+    )
+
+
 def test_format_src_markdown_leading_whitespace():
     before = (
         '```   python\n'


### PR DESCRIPTION
I use [JupyterBook](https://jupyterbook.org) for many of my projects. Here you can write [executable code blocks](https://jupyterbook.org/en/stable/reference/cheatsheet.html#executable-code) using the following markdown directive

````
```{code-cell} python
x = 1 + 2
```
````

We also use `blacken-docs` to make sure all code blocks are formatted with black, but it currently skips the executable code blocks. 

In this PR I add support for an optional `{code-cell}` in the markdown directive. 